### PR TITLE
ci(release): use env in step conditions; allow workflow_dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,9 @@ jobs:
     permissions:
       contents: write
     runs-on: ubuntu-latest
+    env:
+      GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+      PASSPHRASE: ${{ secrets.PASSPHRASE }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.1
@@ -20,13 +23,13 @@ jobs:
           go-version: '1.22'
       - name: Import GPG key (optional)
         id: import_gpg
-        if: ${{ secrets.GPG_PRIVATE_KEY != '' && secrets.PASSPHRASE != '' }}
+        if: ${{ env.GPG_PRIVATE_KEY != '' && env.PASSPHRASE != '' }}
         uses: crazy-max/ghaction-import-gpg@v5.3.0
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.PASSPHRASE }}
       - name: Run GoReleaser (with signing)
-        if: ${{ secrets.GPG_PRIVATE_KEY != '' && secrets.PASSPHRASE != '' }}
+        if: ${{ env.GPG_PRIVATE_KEY != '' && env.PASSPHRASE != '' }}
         uses: goreleaser/goreleaser-action@v5
         with:
           version: v1.24.0
@@ -35,7 +38,7 @@ jobs:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Run GoReleaser (skip signing)
-        if: ${{ secrets.GPG_PRIVATE_KEY == '' || secrets.PASSPHRASE == '' }}
+        if: ${{ env.GPG_PRIVATE_KEY == '' || env.PASSPHRASE == '' }}
         uses: goreleaser/goreleaser-action@v5
         with:
           version: v1.24.0


### PR DESCRIPTION
- Replace secrets.* in step if conditions with env.* to satisfy workflow-dispatch validation.
- No functional change otherwise; still signs when secrets present or skips with --skip=sign.