### PR TITLE
ci(release): use GPG_PASSPHRASE; ensure signed releases for Terraform Registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-      PASSPHRASE: ${{ secrets.PASSPHRASE }}
+      GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.1
@@ -23,13 +23,13 @@ jobs:
           go-version: '1.22'
       - name: Import GPG key (optional)
         id: import_gpg
-        if: ${{ env.GPG_PRIVATE_KEY != '' && env.PASSPHRASE != '' }}
+        if: ${{ env.GPG_PRIVATE_KEY != '' && env.GPG_PASSPHRASE != '' }}
         uses: crazy-max/ghaction-import-gpg@v5.3.0
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-          passphrase: ${{ secrets.PASSPHRASE }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
       - name: Run GoReleaser (with signing)
-        if: ${{ env.GPG_PRIVATE_KEY != '' && env.PASSPHRASE != '' }}
+        if: ${{ env.GPG_PRIVATE_KEY != '' && env.GPG_PASSPHRASE != '' }}
         uses: goreleaser/goreleaser-action@v5
         with:
           version: v1.24.0
@@ -38,7 +38,7 @@ jobs:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Run GoReleaser (skip signing)
-        if: ${{ env.GPG_PRIVATE_KEY == '' || env.PASSPHRASE == '' }}
+        if: ${{ env.GPG_PRIVATE_KEY == '' || env.GPG_PASSPHRASE == '' }}
         uses: goreleaser/goreleaser-action@v5
         with:
           version: v1.24.0


### PR DESCRIPTION
- Rename PASSPHRASE to GPG_PASSPHRASE in workflow secrets and conditions.
- Continue conditional signing: sign when both GPG_PRIVATE_KEY and GPG_PASSPHRASE are present; otherwise skip.
- Required to satisfy Terraform Provider Registry signature requirements.