### PR TITLE
ci(release): use steps.import_gpg.conclusion gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
       - name: Run GoReleaser (with signing)
-        if: ${{ steps.import_gpg.outcome == 'success' }}
+        if: ${{ steps.import_gpg.conclusion == 'success' }}
         uses: goreleaser/goreleaser-action@v5
         with:
           version: v1.24.0
@@ -38,7 +38,7 @@ jobs:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Run GoReleaser (skip signing)
-        if: ${{ steps.import_gpg.outcome != 'success' }}
+        if: ${{ steps.import_gpg.conclusion != 'success' }}
         uses: goreleaser/goreleaser-action@v5
         with:
           version: v1.24.0


### PR DESCRIPTION
Fix conditional signing gate to check `steps.import_gpg.conclusion == 'success'`.