### PR TITLE
ci(release): sign with default imported key (no --local-user)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -44,8 +44,6 @@ signs:
       - --batch
       - --pinentry-mode
       - loopback
-      - --local-user
-      - '{{ .Env.GPG_FINGERPRINT }}'
       - --detach-sign
       - --armor
       - --output


### PR DESCRIPTION
Remove `--local-user` from gpg args to sign with the default imported key; avoids reliance on fingerprint output.