### PR TITLE
ci(release): publish GitHub release (draft: false)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -49,3 +49,7 @@ signs:
       - --output
       - '${signature}'
       - '${artifact}'
+
+release:
+  draft: false
+


### PR DESCRIPTION
Ensure GitHub release is published (not draft) so Terraform Registry can ingest assets.