### PR TITLE
ci(release): use version (no 'v') in artifact filenames

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -52,3 +52,6 @@ signs:
       - --output
       - '${signature}'
       - '${artifact}'
+
+release:
+  draft: false


### PR DESCRIPTION
Switch artifact and checksum filenames to use `.Version` (no leading `v`) so Terraform Registry detects platform assets correctly.