### PR TITLE
ci(release): binary detached signature for SHA256SUMS

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -48,7 +48,6 @@ signs:
       - --pinentry-mode
       - loopback
       - --detach-sign
-      - --armor
       - --output
       - '${signature}'
       - '${artifact}'


### PR DESCRIPTION
Terraform Registry requires a binary, detached GPG signature for SHA256SUMS. Remove `--armor` from GoReleaser signing args to produce a binary `.sig`.